### PR TITLE
 Add top_k Support for Tree Collapsing Functionality

### DIFF
--- a/raptor/RetrievalAugmentation.py
+++ b/raptor/RetrievalAugmentation.py
@@ -224,8 +224,9 @@ class RetrievalAugmentation:
         question,
         start_layer: int = None,
         num_layers: int = None,
+        top_k: int = 10,
         max_tokens: int = 3500,
-        collapse_tree: bool = False,
+        collapse_tree: bool = True,
         return_layer_information: bool = True,
     ):
         """
@@ -253,6 +254,7 @@ class RetrievalAugmentation:
             question,
             start_layer,
             num_layers,
+            top_k,
             max_tokens,
             collapse_tree,
             return_layer_information,
@@ -261,10 +263,11 @@ class RetrievalAugmentation:
     def answer_question(
         self,
         question,
+        top_k: int = 10,
         start_layer: int = None,
         num_layers: int = None,
         max_tokens: int = 3500,
-        collapse_tree: bool = False,
+        collapse_tree: bool = True,
         return_layer_information: bool = False,
     ):
         """
@@ -285,7 +288,7 @@ class RetrievalAugmentation:
         """
         # if return_layer_information:
         context, layer_information = self.retrieve(
-            question, start_layer, num_layers, max_tokens, collapse_tree, True
+            question, start_layer, num_layers, top_k, max_tokens, collapse_tree, True
         )
 
         answer = self.qa_model.answer_question(context, question)

--- a/raptor/tree_retriever.py
+++ b/raptor/tree_retriever.py
@@ -15,6 +15,7 @@ from .utils import (distances_from_embeddings, get_children, get_embeddings,
 
 logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
 
+
 class TreeRetrieverConfig:
     def __init__(
         self,
@@ -154,7 +155,7 @@ class TreeRetriever(BaseRetriever):
         """
         return self.embedding_model.create_embedding(text)
 
-    def retrieve_information_collapse_tree(self, query: str, max_tokens: int) -> str:
+    def retrieve_information_collapse_tree(self, query: str, top_k: int, max_tokens: int) -> str:
         """
         Retrieves the most relevant information from the tree based on the query.
 
@@ -179,7 +180,8 @@ class TreeRetriever(BaseRetriever):
         indices = indices_of_nearest_neighbors_from_distances(distances)
 
         total_tokens = 0
-        for idx in indices:
+        for idx in indices[:top_k]:
+
             node = node_list[idx]
             node_tokens = len(self.tokenizer.encode(node.text))
 
@@ -252,8 +254,9 @@ class TreeRetriever(BaseRetriever):
         query: str,
         start_layer: int = None,
         num_layers: int = None,
+        top_k: int = 10, 
         max_tokens: int = 3500,
-        collapse_tree: bool = False,
+        collapse_tree: bool = True,
         return_layer_information: bool = False,
     ) -> str:
         """
@@ -299,7 +302,7 @@ class TreeRetriever(BaseRetriever):
         if collapse_tree:
             logging.info(f"Using collapsed_tree")
             selected_nodes, context = self.retrieve_information_collapse_tree(
-                query, max_tokens
+                query, top_k, max_tokens
             )
         else:
             layer_nodes = self.tree.layer_to_nodes[start_layer]


### PR DESCRIPTION
This PR introduces the `top_k` parameter to the `retrieve_information_collapse_tree` method in the `TreeRetriever` class. It allows users to control the number of top nodes to consider when retrieving information from the collapsed tree.

Usage:
- The `top_k` parameter is an integer that specifies the number of top nodes to consider during retrieval.
- It defaults to 10 if not provided, meaning the method will consider the top 10 most relevant nodes.
- Users can adjust the value of `top_k` to retrieve more or fewer nodes based on their requirements.

Functionality:
- The `retrieve_information_collapse_tree` method retrieves the most relevant information from the collapsed tree based on the given query.
- It uses the `max_tokens` parameter to limit the maximum number of tokens in the retrieved context, defaulting to 3500 tokens.
- The method calculates the distances between the query embedding and the node embeddings to determine the most relevant nodes.
- It then iterates over the top `top_k` nodes, adding them to the selected nodes list until the token limit is reached.
- it returns the selected nodes and the retrieved context.

